### PR TITLE
Updated Facebook URL's in relation to Facebook breaking changes.

### DIFF
--- a/src/main/java/org/scribe/builder/api/FacebookApi.java
+++ b/src/main/java/org/scribe/builder/api/FacebookApi.java
@@ -6,13 +6,13 @@ import org.scribe.utils.*;
 
 public class FacebookApi extends DefaultApi20
 {
-  private static final String AUTHORIZE_URL = "https://www.facebook.com/dialog/oauth?client_id=%s&redirect_uri=%s";
+  private static final String AUTHORIZE_URL = "https://www.facebook.com/v2.0/dialog/oauth?client_id=%s&redirect_uri=%s";
   private static final String SCOPED_AUTHORIZE_URL = AUTHORIZE_URL + "&scope=%s";
 
   @Override
   public String getAccessTokenEndpoint()
   {
-    return "https://graph.facebook.com/oauth/access_token";
+    return "https://graph.facebook.com/v2.0/oauth/access_token";
   }
 
   @Override


### PR DESCRIPTION
Upgraded Facebook API URL's in relation to implementation of [Facebook API Versioning](https://developers.facebook.com/docs/apps/upgrading?locale=en_GB#v1tov2)

Without tying the library to a specific version, breaking changes would happen when Facebook automatically update to their latest API's. [See Version Schedules) (https://developers.facebook.com/docs/apps/versions?locale=en_GB)

I've upgraded to the earliest possible version to avoid other regressions in this change.