### PR TITLE
Fixes #539 - assertions on oauth response as map ordering has changed due to JDK8...

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Hit Scribe as hard and with many threads as you like.
 
 * Vimeo
 
-* Yammer
-
 * Windows Live
 
 * and many more! check the [examples folder](http://github.com/fernandezpablo85/scribe-java/tree/master/src/test/java/org/scribe/examples)

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-junit</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.1</version>

--- a/src/test/java/org/scribe/extractors/HeaderExtractorTest.java
+++ b/src/test/java/org/scribe/extractors/HeaderExtractorTest.java
@@ -6,6 +6,8 @@ import org.junit.*;
 import org.scribe.exceptions.*;
 import org.scribe.model.*;
 import org.scribe.test.helpers.*;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HeaderExtractorTest
 {
@@ -23,10 +25,12 @@ public class HeaderExtractorTest
   @Test
   public void shouldExtractStandardHeader()
   {
-    String expected = "OAuth oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\", " + "oauth_signature=\"OAuth-Signature\", "
-        + "oauth_consumer_key=\"AS%23%24%5E%2A%40%26\", " + "oauth_timestamp=\"123456\"";
     String header = extractor.extract(request);
-    assertEquals(expected, header);
+
+    assertThat(header, containsString("oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\""));
+    assertThat(header, containsString("oauth_signature=\"OAuth-Signature\""));
+    assertThat(header, containsString("oauth_consumer_key=\"AS%23%24%5E%2A%40%26\""));
+    assertThat(header, containsString("oauth_timestamp=\"123456\""));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
... but ordering isn't important.

Also removed Yammer from README.


