### PR TITLE
add getParameter method for easier query parameter access

### DIFF
--- a/src/main/java/org/scribe/model/Token.java
+++ b/src/main/java/org/scribe/model/Token.java
@@ -56,6 +56,23 @@ public class Token implements Serializable
     return rawResponse;
   }
 
+  public String getParameter(String parameter)
+  {
+    String value = null;
+    for (String str : this.getRawResponse().split("&"))
+    {
+      if (str.startsWith(parameter + '='))
+      {
+        String [] part = str.split("=");
+        if (part.length > 1) {
+          value = part[1].trim();
+        }
+        break;
+      }
+    }
+    return value;
+  }
+
   @Override
   public String toString()
   {

--- a/src/test/java/org/scribe/model/TokenTest.java
+++ b/src/test/java/org/scribe/model/TokenTest.java
@@ -41,4 +41,14 @@ public class TokenTest
     assertNotSame(expected, null);
     assertNotSame(expected, new Object());
   }
+
+  @Test
+  public void shouldReturnUrlParam() throws Exception
+  {
+    Token actual = new Token("acccess", "secret", "user_id=3107154759&screen_name=someuser&empty=&=");
+    assertEquals("someuser", actual.getParameter("screen_name"));
+    assertEquals("3107154759", actual.getParameter("user_id"));
+    assertEquals(null, actual.getParameter("empty"));
+    assertEquals(null, actual.getParameter(null));
+  }
 }


### PR DESCRIPTION
I have to access the `screen_name` after receiving an access token. I think the `Token` class would be a perfect place for such a helper method.